### PR TITLE
Swap Z/L default mapping - works better for most games

### DIFF
--- a/Source/SysVita/Input/InputManagerVita.cpp
+++ b/Source/SysVita/Input/InputManagerVita.cpp
@@ -821,8 +821,8 @@ CControllerConfig *	IInputManager::BuildDefaultConfig()
 
 	p_config->SetButtonMapping( N64Button_A, eval.Parse( "VITA.Cross" ) );
 	p_config->SetButtonMapping( N64Button_B, eval.Parse( "VITA.Square" ) );
-	p_config->SetButtonMapping( N64Button_Z, eval.Parse( "VITA.Triangle" ) );
-	p_config->SetButtonMapping( N64Button_L, eval.Parse( "VITA.LTrigger" ) );
+	p_config->SetButtonMapping( N64Button_Z, eval.Parse( "VITA.LTrigger" ) );
+	p_config->SetButtonMapping( N64Button_L, eval.Parse( "VITA.Triangle" ) );
 	p_config->SetButtonMapping( N64Button_R, eval.Parse( "VITA.RTrigger" ) );
 
 	p_config->SetButtonMapping( N64Button_Up, eval.Parse( "VITA.Up" ) );


### PR DESCRIPTION
Analog controlled games usually depend on the Z button acting as the counterpart to the R button.