### PR TITLE
Added Super Mario 64 (O2) to roms.ini

### DIFF
--- a/Data/DaedalusX64/roms.ini
+++ b/Data/DaedalusX64/roms.ini
@@ -4818,6 +4818,13 @@ Info=
 Preview=super_mario_64.png
 SaveType=Eeprom4k
 
+{b1ca1a049b6739c2-45}
+Name=Super Mario 64 (O2)
+Comment=
+Info=
+Preview=super_mario_64.png
+SaveType=Eeprom4k
+
 {3008cd13e965cf3c-45}
 Name=Super Mario 64 Splitscreen
 Comment=


### PR DESCRIPTION
I added the Super Mario 64 (O2) to the roms.ini database file

**Rom info:**
CRCs: b1ca1a049b6739c2
MD5: 6d6b7c02ece14b4feb390f1f298c0465