### PR TITLE
Added per ROM config

### DIFF
--- a/Source/SysVita/HLEGraphics/RendererVita.cpp
+++ b/Source/SysVita/HLEGraphics/RendererVita.cpp
@@ -29,7 +29,7 @@ extern float *gVertexBuffer;
 extern uint32_t *gColorBuffer;
 extern float *gTexCoordBuffer;
 
-extern bool use_mipmaps;
+bool use_mipmaps = false;
 
 struct ScePspFMatrix4
 {

--- a/Source/SysVita/UI/MainMenuScreen.cpp
+++ b/Source/SysVita/UI/MainMenuScreen.cpp
@@ -90,7 +90,7 @@ void swap(RomSelection *a, RomSelection *b)
 	a->cic = b->cic;
 	a->status = b->status;
 
-    //b->name = nametmp;
+	//b->name = nametmp;
 	memcpy(b->name, nametmp, sizeof nametmp);
 
 	b->settings = settingstmp;
@@ -102,21 +102,21 @@ void swap(RomSelection *a, RomSelection *b)
 
 void sort_list(RomSelection *start, int order) 
 { 
-    int swapped, i; 
-    RomSelection *ptr1; 
-    RomSelection *lptr = NULL; 
+	int swapped, i; 
+	RomSelection *ptr1; 
+	RomSelection *lptr = NULL; 
   
-    /* Checking for empty list */
-    if (start == NULL) 
-        return; 
+	/* Checking for empty list */
+	if (start == NULL) 
+		return; 
   
-    do
-    { 
-        swapped = 0; 
-        ptr1 = start; 
+	do
+	{ 
+		swapped = 0; 
+		ptr1 = start; 
   
-        while (ptr1->next != lptr) 
-        {
+		while (ptr1->next != lptr) 
+		{
 			switch (order) {
 				case SORT_Z_TO_A:
 				{
@@ -139,46 +139,11 @@ void sort_list(RomSelection *start, int order)
 				default:
 					break;
 			}
-            ptr1 = ptr1->next; 
-        } 
-        lptr = ptr1; 
-    } 
-    while (swapped); 
-}
-
-bool loadConfig(char *rom){
-	char configFile[512];
-	char buffer[30];
-	int value;
-
-	char* filename = strdup(rom);
-	sprintf(configFile, "%s%s.ini", DAEDALUS_VITA_PATH("Config/"), filename);
-
-	FILE *config = fopen(configFile, "r");
-	if (config) {
-		while (EOF != fscanf(config, "%[^=]=%d\n", buffer, &value))
-        {
-            if (strcmp("gCPU",buffer) == 0) gCPU = value;
-            if (strcmp("gOSHooksEnabled",buffer) == 0) gOSHooksEnabled = value;
-            if (strcmp("gSpeedSyncEnabled",buffer) == 0) gSpeedSyncEnabled = value;
-            if (strcmp("gVideoRateMatch",buffer) == 0) gVideoRateMatch = value;
-            if (strcmp("gAudioRateMatch",buffer) == 0) gAudioRateMatch = value;
-            if (strcmp("aspect_ratio",buffer) == 0) aspect_ratio = value;
-            if (strcmp("ForceLinearFilter",buffer) == 0) gGlobalPreferences.ForceLinearFilter = value;
-            if (strcmp("use_mipmaps",buffer) == 0) use_mipmaps = value;
-            if (strcmp("use_vsync",buffer) == 0) use_vsync = value;
-            if (strcmp("use_cdram",buffer) == 0) use_cdram = value;
-            if (strcmp("gClearDepthFrameBuffer",buffer) == 0) gClearDepthFrameBuffer = value;
-            if (strcmp("wait_rendering",buffer) == 0) wait_rendering = value;
-            if (strcmp("gAudioPluginEnabled",buffer) == 0) gAudioPluginEnabled = value;
-            if (strcmp("use_mp3",buffer) == 0) use_mp3 = value;
-            if (strcmp("use_expansion_pak",buffer) == 0) use_expansion_pak = value;
-            if (strcmp("gControllerIndex",buffer) == 0) gControllerIndex = value;
-        }
-    	fclose(config);
-		return true;
-	}
-	return false;
+			ptr1 = ptr1->next; 
+		} 
+		lptr = ptr1; 
+	} 
+	while (swapped); 
 }
 
 bool LoadPreview(RomSelection *rom) {
@@ -372,7 +337,6 @@ char *DrawRomSelector() {
 	ImGui::Begin("Info Window", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoBringToFrontOnFocus);
 	
 	if (hovered) {
-		loadConfig(hovered->settings.GameName.c_str());
 		if (has_preview_icon = LoadPreview(hovered)) {
 			ImGui::SetCursorPos(ImVec2(preview_x + PREVIEW_PADDING, preview_y + PREVIEW_PADDING));
 			ImGui::Image((void*)preview_icon, ImVec2(preview_width, preview_height));

--- a/Source/SysVita/UI/MainMenuScreen.cpp
+++ b/Source/SysVita/UI/MainMenuScreen.cpp
@@ -144,7 +144,42 @@ void sort_list(RomSelection *start, int order)
         lptr = ptr1; 
     } 
     while (swapped); 
-}  
+}
+
+bool loadConfig(char *rom){
+	char configFile[512];
+	char buffer[30];
+	int value;
+
+	char* filename = strdup(rom);
+	sprintf(configFile, "%s%s.ini", DAEDALUS_VITA_PATH("Config/"), filename);
+
+	FILE *config = fopen(configFile, "r");
+	if (config) {
+		while (EOF != fscanf(config, "%[^=]=%d\n", buffer, &value))
+        {
+            if (strcmp("gCPU",buffer) == 0) gCPU = value;
+            if (strcmp("gOSHooksEnabled",buffer) == 0) gOSHooksEnabled = value;
+            if (strcmp("gSpeedSyncEnabled",buffer) == 0) gSpeedSyncEnabled = value;
+            if (strcmp("gVideoRateMatch",buffer) == 0) gVideoRateMatch = value;
+            if (strcmp("gAudioRateMatch",buffer) == 0) gAudioRateMatch = value;
+            if (strcmp("aspect_ratio",buffer) == 0) aspect_ratio = value;
+            if (strcmp("ForceLinearFilter",buffer) == 0) gGlobalPreferences.ForceLinearFilter = value;
+            if (strcmp("use_mipmaps",buffer) == 0) use_mipmaps = value;
+            if (strcmp("use_vsync",buffer) == 0) use_vsync = value;
+            if (strcmp("use_cdram",buffer) == 0) use_cdram = value;
+            if (strcmp("gClearDepthFrameBuffer",buffer) == 0) gClearDepthFrameBuffer = value;
+            if (strcmp("wait_rendering",buffer) == 0) wait_rendering = value;
+            if (strcmp("gAudioPluginEnabled",buffer) == 0) gAudioPluginEnabled = value;
+            if (strcmp("use_mp3",buffer) == 0) use_mp3 = value;
+            if (strcmp("use_expansion_pak",buffer) == 0) use_expansion_pak = value;
+            if (strcmp("gControllerIndex",buffer) == 0) gControllerIndex = value;
+        }
+    	fclose(config);
+		return true;
+	}
+	return false;
+}
 
 bool LoadPreview(RomSelection *rom) {
 	if (old_hovered == rom) return has_preview_icon;
@@ -329,7 +364,7 @@ char *DrawRomSelector() {
 		if (ImGui::IsItemHovered()) hovered = p;
 		p = p->next;
 	}
-	
+
 	ImGui::End();
 	
 	ImGui::SetNextWindowPos(ImVec2(SCR_WIDTH - 400, 19), ImGuiSetCond_Always);
@@ -337,6 +372,7 @@ char *DrawRomSelector() {
 	ImGui::Begin("Info Window", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoBringToFrontOnFocus);
 	
 	if (hovered) {
+		loadConfig(hovered->settings.GameName.c_str());
 		if (has_preview_icon = LoadPreview(hovered)) {
 			ImGui::SetCursorPos(ImVec2(preview_x + PREVIEW_PADDING, preview_y + PREVIEW_PADDING));
 			ImGui::Image((void*)preview_icon, ImVec2(preview_width, preview_height));

--- a/Source/SysVita/UI/MainMenuScreen.cpp
+++ b/Source/SysVita/UI/MainMenuScreen.cpp
@@ -120,7 +120,7 @@ void sort_list(RomSelection *start, int order)
 			switch (order) {
 				case SORT_Z_TO_A:
 				{
-					if (strcmp(ptr1->settings.GameName,ptr1->next->settings.GameName) < 0)
+					if (strcmp(ptr1->name,ptr1->next->name) < 0)
 					{  
 						swap(ptr1, ptr1->next); 
 						swapped = 1; 
@@ -129,7 +129,7 @@ void sort_list(RomSelection *start, int order)
 				}
 				case SORT_A_TO_Z:
 				{
-					if (strcmp(ptr1->settings.GameName,ptr1->next->settings.GameName) > 0)
+					if (strcmp(ptr1->name,ptr1->next->name) > 0)
 					{  
 						swap(ptr1, ptr1->next); 
 						swapped = 1; 

--- a/Source/SysVita/UI/Menu.h
+++ b/Source/SysVita/UI/Menu.h
@@ -9,6 +9,11 @@ extern bool show_menubar;
 extern bool hide_menubar;
 extern int use_cdram;
 extern int use_vsync;
+extern int gCPU;
+extern bool use_mp3;
+extern bool wait_rendering;
+extern bool use_expansion_pak;
+extern bool use_mipmaps;
 extern int sort_order;
 
 char *DrawRomSelector();

--- a/Source/SysVita/UI/Menu.h
+++ b/Source/SysVita/UI/Menu.h
@@ -5,6 +5,13 @@ enum {
 	SORT_Z_TO_A
 };
 
+enum {
+	CPU_DYNAREC_UNSAFE,
+	CPU_DYNAREC_SAFE,
+	CPU_CACHED_INTERPRETER,
+	CPU_INTERPRETER
+};
+
 extern bool show_menubar;
 extern bool hide_menubar;
 extern int use_cdram;

--- a/Source/SysVita/UI/Menu.h
+++ b/Source/SysVita/UI/Menu.h
@@ -29,3 +29,4 @@ void DrawMenuBar();
 void DrawInGameMenuBar();
 void DrawDownloaderScreen(int index, float downloaded_bytes, float total_bytes);
 void SetupVFlux();
+void setCPUMode();

--- a/Source/SysVita/UI/MenuBarScreen.cpp
+++ b/Source/SysVita/UI/MenuBarScreen.cpp
@@ -173,29 +173,23 @@ void DrawCommonMenuBar() {
 	if (ImGui::BeginMenu("Emulation")){
 		if (ImGui::BeginMenu("CPU")){
 			if (ImGui::MenuItem("DynaRec (Unsafe)", nullptr, gCPU == CPU_DYNAREC_UNSAFE)){
-				gDynarecEnabled = true;
-				gUnsafeDynarecOptimisations = true;
-				gUseCachedInterpreter = false;
 				gCPU = CPU_DYNAREC_UNSAFE;
+				setCPUMode();
 			}
 			SetDescription("Enables full dynamic recompilation for best performances.");
 			if (ImGui::MenuItem("DynaRec (Safe)", nullptr, gCPU == CPU_DYNAREC_SAFE)){
-				gDynarecEnabled = true;
-				gUnsafeDynarecOptimisations = false;
-				gUseCachedInterpreter = false;
 				gCPU = CPU_DYNAREC_SAFE;
+				setCPUMode();
 			}
 			SetDescription("Enables safe dynamic recompilation for good performances and better compatibility.");
 			if (ImGui::MenuItem("Cached Interpreter", nullptr, gCPU == CPU_CACHED_INTERPRETER)){
-				gUseCachedInterpreter = true;
-				gDynarecEnabled = true;
 				gCPU = CPU_CACHED_INTERPRETER;
+				setCPUMode();
 			}
 			SetDescription("Enables cached interpreter for decent performances and better compatibility.");
 			if (ImGui::MenuItem("Interpreter", nullptr, gCPU == CPU_INTERPRETER)){
-				gUseCachedInterpreter = false;
-				gDynarecEnabled = false;
 				gCPU = CPU_INTERPRETER;
+				setCPUMode();
 			}
 			SetDescription("Enables interpreter for best compatibility.");
 			ImGui::EndMenu();

--- a/Source/SysVita/UI/MenuBarScreen.cpp
+++ b/Source/SysVita/UI/MenuBarScreen.cpp
@@ -56,7 +56,7 @@ bool show_menubar = true;
 bool hide_menubar = true;
 bool run_emu = true;
 bool restart_rom = false;
-int gCPU = 1;
+int gCPU = CPU_DYNAREC_UNSAFE;
 int sort_order = SORT_A_TO_Z;
 
 static bool vflux_window = false;
@@ -106,27 +106,27 @@ void saveConfig(){
 
 	FILE *config = fopen(configFile, "w+");
 	if (config != NULL) {
-        fprintf(config, "%s=%d\n", "gCPU", gCPU);
-        fprintf(config, "%s=%d\n", "gOSHooksEnabled", gOSHooksEnabled);
-        fprintf(config, "%s=%d\n", "gSpeedSyncEnabled", gSpeedSyncEnabled);
-        
-        fprintf(config, "%s=%d\n", "gVideoRateMatch", gVideoRateMatch);
-        fprintf(config, "%s=%d\n", "gAudioRateMatch", gAudioRateMatch);
-        fprintf(config, "%s=%d\n", "aspect_ratio",aspect_ratio);
-        fprintf(config, "%s=%d\n", "gCheckTextureHashFrequency", gCheckTextureHashFrequency);
-        fprintf(config, "%s=%d\n", "ForceLinearFilter", gGlobalPreferences.ForceLinearFilter);
-        
-        fprintf(config, "%s=%d\n", "use_mipmaps", use_mipmaps);
-        fprintf(config, "%s=%d\n", "use_vsync", use_vsync);
-        fprintf(config, "%s=%d\n", "use_cdram", use_cdram);
-        fprintf(config, "%s=%d\n", "gClearDepthFrameBuffer", gClearDepthFrameBuffer);
-        fprintf(config, "%s=%d\n", "wait_rendering", wait_rendering);
-        
-        fprintf(config, "%s=%d\n", "gAudioPluginEnabled", gAudioPluginEnabled);
-        fprintf(config, "%s=%d\n", "use_mp3", use_mp3);
-        
-        fprintf(config, "%s=%d\n", "use_expansion_pak", use_expansion_pak);
-        fprintf(config, "%s=%d\n", "gControllerIndex", gControllerIndex);
+		fprintf(config, "%s=%d\n", "gCPU", gCPU);
+		fprintf(config, "%s=%d\n", "gOSHooksEnabled", gOSHooksEnabled);
+		fprintf(config, "%s=%d\n", "gSpeedSyncEnabled", gSpeedSyncEnabled);
+		
+		fprintf(config, "%s=%d\n", "gVideoRateMatch", gVideoRateMatch);
+		fprintf(config, "%s=%d\n", "gAudioRateMatch", gAudioRateMatch);
+		fprintf(config, "%s=%d\n", "aspect_ratio",aspect_ratio);
+		fprintf(config, "%s=%d\n", "gCheckTextureHashFrequency", gCheckTextureHashFrequency);
+		fprintf(config, "%s=%d\n", "ForceLinearFilter", gGlobalPreferences.ForceLinearFilter);
+		
+		fprintf(config, "%s=%d\n", "use_mipmaps", use_mipmaps);
+		fprintf(config, "%s=%d\n", "use_vsync", use_vsync);
+		fprintf(config, "%s=%d\n", "use_cdram", use_cdram);
+		fprintf(config, "%s=%d\n", "gClearDepthFrameBuffer", gClearDepthFrameBuffer);
+		fprintf(config, "%s=%d\n", "wait_rendering", wait_rendering);
+		
+		fprintf(config, "%s=%d\n", "gAudioPluginEnabled", gAudioPluginEnabled);
+		fprintf(config, "%s=%d\n", "use_mp3", use_mp3);
+		
+		fprintf(config, "%s=%d\n", "use_expansion_pak", use_expansion_pak);
+		fprintf(config, "%s=%d\n", "gControllerIndex", gControllerIndex);
 		fflush(config);
 		fclose(config);
 	}
@@ -172,26 +172,30 @@ void DrawCommonMenuBar() {
 	sceCtrlGetControllerPortInfo(&pinfo);
 	if (ImGui::BeginMenu("Emulation")){
 		if (ImGui::BeginMenu("CPU")){
-			if (ImGui::MenuItem("DynaRec (Unsafe)", nullptr, gCPU == 1)){
+			if (ImGui::MenuItem("DynaRec (Unsafe)", nullptr, gCPU == CPU_DYNAREC_UNSAFE)){
 				gDynarecEnabled = true;
 				gUnsafeDynarecOptimisations = true;
 				gUseCachedInterpreter = false;
+				gCPU = CPU_DYNAREC_UNSAFE;
 			}
 			SetDescription("Enables full dynamic recompilation for best performances.");
-			if (ImGui::MenuItem("DynaRec (Safe)", nullptr, gCPU == 2)){
+			if (ImGui::MenuItem("DynaRec (Safe)", nullptr, gCPU == CPU_DYNAREC_SAFE)){
 				gDynarecEnabled = true;
 				gUnsafeDynarecOptimisations = false;
 				gUseCachedInterpreter = false;
+				gCPU = CPU_DYNAREC_SAFE;
 			}
 			SetDescription("Enables safe dynamic recompilation for good performances and better compatibility.");
-			if (ImGui::MenuItem("Cached Interpreter", nullptr, gCPU == 3)){
+			if (ImGui::MenuItem("Cached Interpreter", nullptr, gCPU == CPU_CACHED_INTERPRETER)){
 				gUseCachedInterpreter = true;
 				gDynarecEnabled = true;
+				gCPU = CPU_CACHED_INTERPRETER;
 			}
 			SetDescription("Enables cached interpreter for decent performances and better compatibility.");
-			if (ImGui::MenuItem("Interpreter", nullptr, gCPU == 4)){
+			if (ImGui::MenuItem("Interpreter", nullptr, gCPU == CPU_INTERPRETER)){
 				gUseCachedInterpreter = false;
 				gDynarecEnabled = false;
+				gCPU = CPU_INTERPRETER;
 			}
 			SetDescription("Enables interpreter for best compatibility.");
 			ImGui::EndMenu();
@@ -499,10 +503,10 @@ void DrawInGameMenuBar() {
 	if (show_menubar) {
 		if (ImGui::BeginMainMenuBar()){
 			if (ImGui::BeginMenu("Files")){
-		        if (ImGui::MenuItem("Save ROM config")){
-			        saveConfig();
-		        }
-		        ImGui::Separator();
+				if (ImGui::MenuItem("Save ROM config")){
+					saveConfig();
+				}
+				ImGui::Separator();
 				if (ImGui::BeginMenu("Save Savestate")){
 					for (int i = 0; i <= MAX_SAVESLOT; i++) {
 						char tag[8];

--- a/Source/SysVita/main.cpp
+++ b/Source/SysVita/main.cpp
@@ -303,8 +303,7 @@ int main(int argc, char* argv[])
 
 	loadConfig();
 
-	while (run_emu)
-	{
+	while (run_emu) {
 		EnableMenuButtons(true);
 
 		if (restart_rom) restart_rom = false;

--- a/Source/SysVita/main.cpp
+++ b/Source/SysVita/main.cpp
@@ -34,11 +34,10 @@
 #include "Utility/Timer.h"
 #include "UI/Menu.h"
 
-#define NET_INIT_SIZE 1 * 1024 * 1024
+#define NET_INIT_SIZE 1*1024*1024
 #define TEMP_DOWNLOAD_NAME "ux0:data/DaedalusX64/tmp.bin"
 
-extern "C"
-{
+extern "C" {
 	int32_t sceKernelChangeThreadVfpException(int32_t clear, int32_t set);
 	int _newlib_heap_size_user = 160 * 1024 * 1024;
 }
@@ -56,8 +55,7 @@ static SceUID net_mutex;
 int use_cdram = GL_TRUE;
 int use_vsync = GL_TRUE;
 
-void log2file(const char *format, ...)
-{
+void log2file(const char *format, ...) {
 	__gnuc_va_list arg;
 	va_start(arg, format);
 	char msg[512];
@@ -65,25 +63,21 @@ void log2file(const char *format, ...)
 	va_end(arg);
 	sprintf(msg, "%s\n", msg);
 	FILE *log = fopen("ux0:/data/DaedalusX64.log", "a+");
-	if (log != NULL)
-	{
+	if (log != NULL) {
 		fwrite(msg, 1, strlen(msg), log);
 		fclose(log);
 	}
 }
 
-void dump2file(void *ptr, uint32_t size)
-{
+void dump2file(void *ptr, uint32_t size) {
 	FILE *log = fopen("ux0:/data/DaedalusX64.dmp", "a+");
-	if (log != NULL)
-	{
+	if (log != NULL) {
 		fwrite(ptr, 1, size, log);
 		fclose(log);
 	}
 }
 
-static void EnableMenuButtons(bool status)
-{
+static void EnableMenuButtons(bool status) {
 	ImGui_ImplVitaGL_GamepadUsage(status);
 	ImGui_ImplVitaGL_MouseStickUsage(status);
 }
@@ -131,12 +125,10 @@ static void startDownload(const char *url)
 	curl_easy_perform(curl_handle);
 }
 
-static int downloadThread(unsigned int args, void *arg)
-{
+static int downloadThread(unsigned int args, void *arg){
 	char url[512], dbname[64];
 	curl_handle = curl_easy_init();
-	for (int i = 1; i <= NUM_DB_CHUNKS; i++)
-	{
+	for (int i = 1; i <= NUM_DB_CHUNKS; i++) {
 		sceKernelWaitSema(net_mutex, 1, NULL);
 		sprintf(dbname, "%sdb%ld.json", DAEDALUS_VITA_MAIN_PATH, i);
 		sprintf(url, "https://api.github.com/repos/Rinnegatamante/DaedalusX64-vitaGL-Compatibility/issues?state=open&page=%ld&per_page=100", i);
@@ -152,13 +144,11 @@ static int downloadThread(unsigned int args, void *arg)
 		startDownload(url);
 
 		fclose(fh);
-		if (downloaded_bytes > 12 * 1024)
-		{
+		if (downloaded_bytes > 12 * 1024) {
 			sceIoRemove(dbname);
 			sceIoRename(TEMP_DOWNLOAD_NAME, dbname);
 		}
-		else
-			sceIoRemove(TEMP_DOWNLOAD_NAME);
+		else sceIoRemove(TEMP_DOWNLOAD_NAME);
 		downloaded_bytes = total_bytes;
 	}
 	curl_easy_cleanup(curl_handle);
@@ -208,8 +198,7 @@ static void Initialize()
 
 	// Initializing dear ImGui
 	ImGui::CreateContext();
-	ImGuiIO &io = ImGui::GetIO();
-	(void)io;
+	ImGuiIO &io = ImGui::GetIO(); (void)io;
 	ImGui_ImplVitaGL_Init();
 	ImGui_ImplVitaGL_TouchUsage(true);
 	ImGui_ImplVitaGL_UseIndirectFrontTouch(true);
@@ -218,11 +207,9 @@ static void Initialize()
 
 	// Downloading compatibility databases
 	sceKernelStartThread(thd, 0, NULL);
-	for (int i = 1; i <= NUM_DB_CHUNKS; i++)
-	{
+	for (int i = 1; i <= NUM_DB_CHUNKS; i++) {
 		sceKernelSignalSema(net_mutex, 1);
-		while (downloaded_bytes < total_bytes)
-		{
+		while (downloaded_bytes < total_bytes) {
 			DrawDownloaderScreen(i, downloaded_bytes, total_bytes);
 		}
 		total_bytes++;
@@ -283,42 +270,24 @@ bool loadConfig()
 
 	if (config)
 	{
-		DBGConsole_Msg(0, "loading: [G%s]", configFile);
-
 		while (EOF != fscanf(config, "%[^=]=%d\n", buffer, &value))
 		{
-			if (strcmp("gCPU", buffer) == 0)
-				gCPU = value;
-			if (strcmp("gOSHooksEnabled", buffer) == 0)
-				gOSHooksEnabled = value;
-			if (strcmp("gSpeedSyncEnabled", buffer) == 0)
-				gSpeedSyncEnabled = value;
-			if (strcmp("gVideoRateMatch", buffer) == 0)
-				gVideoRateMatch = value;
-			if (strcmp("gAudioRateMatch", buffer) == 0)
-				gAudioRateMatch = value;
-			if (strcmp("aspect_ratio", buffer) == 0)
-				aspect_ratio = value;
-			if (strcmp("ForceLinearFilter", buffer) == 0)
-				gGlobalPreferences.ForceLinearFilter = value;
-			if (strcmp("use_mipmaps", buffer) == 0)
-				use_mipmaps = value;
-			if (strcmp("use_vsync", buffer) == 0)
-				use_vsync = value;
-			if (strcmp("use_cdram", buffer) == 0)
-				use_cdram = value;
-			if (strcmp("gClearDepthFrameBuffer", buffer) == 0)
-				gClearDepthFrameBuffer = value;
-			if (strcmp("wait_rendering", buffer) == 0)
-				wait_rendering = value;
-			if (strcmp("gAudioPluginEnabled", buffer) == 0)
-				gAudioPluginEnabled = value;
-			if (strcmp("use_mp3", buffer) == 0)
-				use_mp3 = value;
-			if (strcmp("use_expansion_pak", buffer) == 0)
-				use_expansion_pak = value;
-			if (strcmp("gControllerIndex", buffer) == 0)
-				gControllerIndex = value;
+			if (strcmp("gCPU", buffer) == 0) gCPU = value;
+			if (strcmp("gOSHooksEnabled", buffer) == 0) gOSHooksEnabled = value;
+			if (strcmp("gSpeedSyncEnabled", buffer) == 0) gSpeedSyncEnabled = value;
+			if (strcmp("gVideoRateMatch", buffer) == 0) gVideoRateMatch = value;
+			if (strcmp("gAudioRateMatch", buffer) == 0) gAudioRateMatch = value;
+			if (strcmp("aspect_ratio", buffer) == 0) aspect_ratio = value;
+			if (strcmp("ForceLinearFilter", buffer) == 0) gGlobalPreferences.ForceLinearFilter = value;
+			if (strcmp("use_mipmaps", buffer) == 0) use_mipmaps = value;
+			if (strcmp("use_vsync", buffer) == 0) use_vsync = value;
+			if (strcmp("use_cdram", buffer) == 0) use_cdram = value;
+			if (strcmp("gClearDepthFrameBuffer", buffer) == 0) gClearDepthFrameBuffer = value;
+			if (strcmp("wait_rendering", buffer) == 0) wait_rendering = value;
+			if (strcmp("gAudioPluginEnabled", buffer) == 0) gAudioPluginEnabled = value;
+			if (strcmp("use_mp3", buffer) == 0) use_mp3 = value;
+			if (strcmp("use_expansion_pak", buffer) == 0) use_expansion_pak = value;
+			if (strcmp("gControllerIndex", buffer) == 0) gControllerIndex = value;
 		}
 		fclose(config);
 
@@ -328,7 +297,7 @@ bool loadConfig()
 	return false;
 }
 
-int main(int argc, char *argv[])
+int main(int argc, char* argv[])
 {
 	Initialize();
 
@@ -340,13 +309,11 @@ int main(int argc, char *argv[])
 	{
 		EnableMenuButtons(true);
 
-		if (restart_rom)
-			restart_rom = false;
+		if (restart_rom) restart_rom = false;
 		else
 		{
 			rom = nullptr;
-			do
-			{
+			do {
 				rom = DrawRomSelector();
 			} while (rom == nullptr);
 		}

--- a/Source/SysVita/main.cpp
+++ b/Source/SysVita/main.cpp
@@ -125,7 +125,7 @@ static void startDownload(const char *url)
 	curl_easy_perform(curl_handle);
 }
 
-static int downloadThread(unsigned int args, void *arg){
+static int downloadThread(unsigned int args, void* arg){
 	char url[512], dbname[64];
 	curl_handle = curl_easy_init();
 	for (int i = 1; i <= NUM_DB_CHUNKS; i++) {
@@ -147,8 +147,7 @@ static int downloadThread(unsigned int args, void *arg){
 		if (downloaded_bytes > 12 * 1024) {
 			sceIoRemove(dbname);
 			sceIoRename(TEMP_DOWNLOAD_NAME, dbname);
-		}
-		else sceIoRemove(TEMP_DOWNLOAD_NAME);
+		} else sceIoRemove(TEMP_DOWNLOAD_NAME);
 		downloaded_bytes = total_bytes;
 	}
 	curl_easy_cleanup(curl_handle);
@@ -178,8 +177,7 @@ static void Initialize()
 	int ret = sceNetShowNetstat();
 	void *net_memory = nullptr;
 	SceNetInitParam initparam;
-	if (ret == SCE_NET_ERROR_ENOTINIT)
-	{
+	if (ret == SCE_NET_ERROR_ENOTINIT) {
 		net_memory = malloc(NET_INIT_SIZE);
 		initparam.memory = net_memory;
 		initparam.size = NET_INIT_SIZE;
@@ -198,7 +196,7 @@ static void Initialize()
 
 	// Initializing dear ImGui
 	ImGui::CreateContext();
-	ImGuiIO &io = ImGui::GetIO(); (void)io;
+	ImGuiIO& io = ImGui::GetIO(); (void)io;
 	ImGui_ImplVitaGL_Init();
 	ImGui_ImplVitaGL_TouchUsage(true);
 	ImGui_ImplVitaGL_UseIndirectFrontTouch(true);
@@ -310,8 +308,7 @@ int main(int argc, char* argv[])
 		EnableMenuButtons(true);
 
 		if (restart_rom) restart_rom = false;
-		else
-		{
+		else {
 			rom = nullptr;
 			do {
 				rom = DrawRomSelector();

--- a/Source/SysVita/main.cpp
+++ b/Source/SysVita/main.cpp
@@ -222,6 +222,42 @@ static void Initialize()
 	free(net_memory);
 }
 
+bool loadConfig(){
+	char configFile[512];
+	char buffer[30];
+	int value;
+
+	char* filename = strdup(g_ROM.settings.GameName.c_str());
+
+	sprintf(configFile, "%s%s.ini", DAEDALUS_VITA_PATH("Config/"), filename);
+
+	FILE *config = fopen(configFile, "r");
+	if (config) {
+		while (EOF != fscanf(config, "%[^=]=%d\n", buffer, &value))
+        {
+            if (strcmp("gCPU",buffer) == 0) gCPU = value;
+            if (strcmp("gOSHooksEnabled",buffer) == 0) gOSHooksEnabled = value;
+            if (strcmp("gSpeedSyncEnabled",buffer) == 0) gSpeedSyncEnabled = value;
+            if (strcmp("gVideoRateMatch",buffer) == 0) gVideoRateMatch = value;
+            if (strcmp("gAudioRateMatch",buffer) == 0) gAudioRateMatch = value;
+            if (strcmp("aspect_ratio",buffer) == 0) aspect_ratio = value;
+            if (strcmp("ForceLinearFilter",buffer) == 0) gGlobalPreferences.ForceLinearFilter = value;
+            if (strcmp("use_mipmaps",buffer) == 0) use_mipmaps = value;
+            if (strcmp("use_vsync",buffer) == 0) use_vsync = value;
+            if (strcmp("use_cdram",buffer) == 0) use_cdram = value;
+            if (strcmp("gClearDepthFrameBuffer",buffer) == 0) gClearDepthFrameBuffer = value;
+            if (strcmp("wait_rendering",buffer) == 0) wait_rendering = value;
+            if (strcmp("gAudioPluginEnabled",buffer) == 0) gAudioPluginEnabled = value;
+            if (strcmp("use_mp3",buffer) == 0) use_mp3 = value;
+            if (strcmp("use_expansion_pak",buffer) == 0) use_expansion_pak = value;
+            if (strcmp("gControllerIndex",buffer) == 0) gControllerIndex = value;
+        }
+    	fclose(config);
+		return true;
+	}
+	return false;
+}
+
 int main(int argc, char* argv[])
 {
 	Initialize();
@@ -243,6 +279,7 @@ int main(int argc, char* argv[])
 		sprintf(fullpath, "%s%s", DAEDALUS_VITA_PATH("Roms/"), rom);
 		EnableMenuButtons(false);
 		System_Open(fullpath);
+		//loadConfig();
 		CPU_Run();
 		System_Close();
 	}

--- a/Source/SysVita/main.cpp
+++ b/Source/SysVita/main.cpp
@@ -222,6 +222,30 @@ static void Initialize()
 	free(net_memory);
 }
 
+void setCPUMode(){
+		switch (gCPU){
+			case CPU_DYNAREC_SAFE:
+				gDynarecEnabled = true;
+				gUnsafeDynarecOptimisations = false;
+				gUseCachedInterpreter = false;			
+				break;
+			case CPU_CACHED_INTERPRETER:
+				gUseCachedInterpreter = true;
+				gDynarecEnabled = true;			
+				break;
+			case CPU_INTERPRETER:
+				gUseCachedInterpreter = false;
+				gDynarecEnabled = false;			
+				break;
+			case CPU_DYNAREC_UNSAFE:
+			default:
+				gDynarecEnabled = true;
+				gUnsafeDynarecOptimisations = true;
+				gUseCachedInterpreter = false;			
+				break;									
+		}
+}
+
 bool loadConfig(){
 	char configFile[512];
 	char buffer[30];
@@ -234,25 +258,26 @@ bool loadConfig(){
 	FILE *config = fopen(configFile, "r");
 	if (config) {
 		while (EOF != fscanf(config, "%[^=]=%d\n", buffer, &value))
-        {
-            if (strcmp("gCPU",buffer) == 0) gCPU = value;
-            if (strcmp("gOSHooksEnabled",buffer) == 0) gOSHooksEnabled = value;
-            if (strcmp("gSpeedSyncEnabled",buffer) == 0) gSpeedSyncEnabled = value;
-            if (strcmp("gVideoRateMatch",buffer) == 0) gVideoRateMatch = value;
-            if (strcmp("gAudioRateMatch",buffer) == 0) gAudioRateMatch = value;
-            if (strcmp("aspect_ratio",buffer) == 0) aspect_ratio = value;
-            if (strcmp("ForceLinearFilter",buffer) == 0) gGlobalPreferences.ForceLinearFilter = value;
-            if (strcmp("use_mipmaps",buffer) == 0) use_mipmaps = value;
-            if (strcmp("use_vsync",buffer) == 0) use_vsync = value;
-            if (strcmp("use_cdram",buffer) == 0) use_cdram = value;
-            if (strcmp("gClearDepthFrameBuffer",buffer) == 0) gClearDepthFrameBuffer = value;
-            if (strcmp("wait_rendering",buffer) == 0) wait_rendering = value;
-            if (strcmp("gAudioPluginEnabled",buffer) == 0) gAudioPluginEnabled = value;
-            if (strcmp("use_mp3",buffer) == 0) use_mp3 = value;
-            if (strcmp("use_expansion_pak",buffer) == 0) use_expansion_pak = value;
-            if (strcmp("gControllerIndex",buffer) == 0) gControllerIndex = value;
-        }
-    	fclose(config);
+		{
+			if (strcmp("gCPU",buffer) == 0) gCPU = value;
+			if (strcmp("gOSHooksEnabled",buffer) == 0) gOSHooksEnabled = value;
+			if (strcmp("gSpeedSyncEnabled",buffer) == 0) gSpeedSyncEnabled = value;
+			if (strcmp("gVideoRateMatch",buffer) == 0) gVideoRateMatch = value;
+			if (strcmp("gAudioRateMatch",buffer) == 0) gAudioRateMatch = value;
+			if (strcmp("aspect_ratio",buffer) == 0) aspect_ratio = value;
+			if (strcmp("ForceLinearFilter",buffer) == 0) gGlobalPreferences.ForceLinearFilter = value;
+			if (strcmp("use_mipmaps",buffer) == 0) use_mipmaps = value;
+			if (strcmp("use_vsync",buffer) == 0) use_vsync = value;
+			if (strcmp("use_cdram",buffer) == 0) use_cdram = value;
+			if (strcmp("gClearDepthFrameBuffer",buffer) == 0) gClearDepthFrameBuffer = value;
+			if (strcmp("wait_rendering",buffer) == 0) wait_rendering = value;
+			if (strcmp("gAudioPluginEnabled",buffer) == 0) gAudioPluginEnabled = value;
+			if (strcmp("use_mp3",buffer) == 0) use_mp3 = value;
+			if (strcmp("use_expansion_pak",buffer) == 0) use_expansion_pak = value;
+			if (strcmp("gControllerIndex",buffer) == 0) gControllerIndex = value;
+		}
+		fclose(config);
+
 		return true;
 	}
 	return false;
@@ -279,7 +304,8 @@ int main(int argc, char* argv[])
 		sprintf(fullpath, "%s%s", DAEDALUS_VITA_PATH("Roms/"), rom);
 		EnableMenuButtons(false);
 		System_Open(fullpath);
-		//loadConfig();
+		loadConfig();
+		setCPUMode();
 		CPU_Run();
 		System_Close();
 	}


### PR DESCRIPTION
While in-game, in the File menu, an option has been added to save the current ROM config as a <GameName>.ini 
These files are stored on the Config/ dir, and when a game is loaded, the emulators checks if a config file exists for the game, if so, it's loaded.
This will allow to create custom configs for each game, because many games work better with some specific config that doesn't work well for other games. Users could submit their configs and create some kind of config repo.

Config files are as follows

```
gCPU=0
gOSHooksEnabled=1
gSpeedSyncEnabled=0
gVideoRateMatch=0
gAudioRateMatch=0
aspect_ratio=3
gCheckTextureHashFrequency=1
ForceLinearFilter=0
use_mipmaps=0
use_vsync=1
use_cdram=1
gClearDepthFrameBuffer=0
wait_rendering=0
gAudioPluginEnabled=2
use_mp3=1
use_expansion_pak=1
gControllerIndex=0
```

I haven't tested it, but lines with comments starting with # are allowed