### PR TITLE
Update roms.ini

### DIFF
--- a/Data/DaedalusX64/roms.ini
+++ b/Data/DaedalusX64/roms.ini
@@ -5084,6 +5084,13 @@ Info=
 Preview=LoZ_OoT_GC.png
 SaveType=SRAM
 
+{9648d06547ac0c04-45}
+Name=THE LEGEND OF ZELDA
+Comment=
+Info=
+Preview=LoZ_OoT_1.0.png
+SaveType=SRAM
+
 {69b544b085193c37-50}
 Name=The Legend of Zelda - Ocarina of Time (v1.0)
 Comment=

--- a/Data/DaedalusX64/roms.ini
+++ b/Data/DaedalusX64/roms.ini
@@ -5085,7 +5085,7 @@ Preview=LoZ_OoT_GC.png
 SaveType=SRAM
 
 {9648d06547ac0c04-45}
-Name=THE LEGEND OF ZELDA
+Name=The Legend of Zelda - Ocarina of Time Redux (v1.0)
 Comment=
 Info=
 Preview=LoZ_OoT_1.0.png


### PR DESCRIPTION
added ocarina of time redux.

    Text speed now goes 3 times.
    Collecting Gold Skulltulla Tokens no longer freezes the player but allows it to continue moving. This is similar to what happens in Majora’s Mask spider houses.
    D-PAD can be used to quickly access ocarina and iron/hover boots.
    Rupee color of the rupee count indicator now changes in color to reflect the wallet upgrade possessed.
    Stone of Agony now works even without rumble. An icon will appear over the rupee count when in proximity of a hidden grotto.
    File select screen now displays all collected items instead of simply showing hearts and medallions/stones.
    Increased speed of block pushing.
    Farore’s Wind does not get dispelled through time travel and can be used independently by child and adult Link.
    The bunny hood now works like in Majora’s Mask boosting movement speed when worn.
    Dampe’s digging tour prize is guaranteed first try instead of random. Additionally he can dig anywhere instead of only on dirt patches.
    Bombchu Bowling prizes now appear in fixed order instead of random (Rotation being: piece of heart, purple rupee, bomb bag capacity upgrade, bombs).
    Fishing made easier by removing most RNG and guaranteeing biting. Additionally a win-requirements big fish is added by himself in the top-left region of the pond.
    Biggoron has you wait 2 days instead of 3 to forge the Biggoron Sword.
    Default Z-targeting is automatically set to HOLD by default.
    Burning Kakariko cutscene now starts by entering Kakariko from any entrance instead of only the main one.
    Song of Storms cooldown is removed, additionally it can be used in every ambient.
    Lab diving heart piece can now be obtained at all times.
    Warp songs and Farore’s Wind can now be used inside Gerudo Training Grounds and Ganon’s Castle.
    All other vanilla features (Rewards, Cutscenes and Animations) are retained.
